### PR TITLE
add - signer to sign update-center json

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-target
 .idea
 *.iml
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM maven
 MAINTAINER Merkushev Kirill (github:lanwen)
 
 ENV JUSEPPE_BASE_DIR        /juseppe
+ENV JUSEPPE_CERT_DIR        ${JUSEPPE_BASE_DIR}/cert
 ENV JUSEPPE_PLUGINS_DIR     ${JUSEPPE_BASE_DIR}/plugins
 ENV JUSEPPE_SAVE_TO_DIR     ${JUSEPPE_BASE_DIR}/json
 ENV JUSEPPE_JSON_NAME       update-center.json
@@ -9,13 +10,28 @@ ENV JUSEPPE_BASE_URI        http://localhost:8080
 
 RUN mkdir ${JUSEPPE_BASE_DIR} \
     && mkdir ${JUSEPPE_PLUGINS_DIR} \
+    && mkdir ${JUSEPPE_CERT_DIR} \
     && mkdir ${JUSEPPE_SAVE_TO_DIR}
     
 ADD . ${JUSEPPE_BASE_DIR}
 WORKDIR ${JUSEPPE_BASE_DIR}
 
+#Locally can be replaced with "mvn package && docker build ..." to avoid downloading lot of jars
 RUN ["mvn", "package"]
+
+# Self-signed certificate
+RUN openssl genrsa -out ${JUSEPPE_CERT_DIR}/uc.key 2048 \
+&& openssl req -nodes -x509 -new \
+    -key ${JUSEPPE_CERT_DIR}/uc.key \
+    -out ${JUSEPPE_CERT_DIR}/uc.crt \
+    -days 1056 \
+    -subj "/C=EN/ST=Update-Center/L=Juseppe/O=Juseppe"
 
 EXPOSE 8080
 
-CMD java -jar -Dupdate.center.plugins.dir=${JUSEPPE_PLUGINS_DIR} -Dupdate.center.saveto.dir=${JUSEPPE_SAVE_TO_DIR} -Dupdate.center.json.name=${JUSEPPE_JSON_NAME} -Dupdate.center.baseurl=${JUSEPPE_BASE_URI} target/juseppe.jar
+CMD java -jar -Dupdate.center.plugins.dir=${JUSEPPE_PLUGINS_DIR} \
+                -Dupdate.center.saveto.dir=${JUSEPPE_SAVE_TO_DIR} \
+                -Dupdate.center.json.name=${JUSEPPE_JSON_NAME} \
+                -Dupdate.center.private.key=${JUSEPPE_CERT_DIR}/uc.key \
+                -Dupdate.center.certificate=${JUSEPPE_CERT_DIR}/uc.crt \
+                -Dupdate.center.baseurl=${JUSEPPE_BASE_URI} target/juseppe.jar

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You can define system properties to override default behaviour:
 - `update.center.plugins.dir` - where the plugins are. Searches only `*.hpi`. Defaults to *current working dir*
 - `update.center.saveto.dir` - where to save generated json file. Defaults to *current working dir*
 - `update.center.json.name` - name of generated json file. Defaults to `update-center.json`
+- `update.center.private.key` - path of private key (must be used in pair with cert). Defaults to *uc.key*
+- `update.center.certificate` - path of certificate (must be used in pair with private key prop). Defaults to *uc.crt* 
 - `update.center.baseurl` - url to prepend for plugins download link in json. Defaults to `http://localhost:8080`
 - `jetty.port` - port for file server. Defaults to `8080`
 
@@ -31,8 +33,7 @@ Example:
 
 Site can be added with help of: 
     
-- [UpdateSites Manager plugin](https://wiki.jenkins-ci.org/display/JENKINS/UpdateSites+Manager+plugin) (With PR of ignored sign check for now)
-- [SimpleUpdateSite Plugin](https://wiki.jenkins-ci.org/display/JENKINS/SimpleUpdateSite+Plugin)
+- [UpdateSites Manager plugin](https://wiki.jenkins-ci.org/display/JENKINS/UpdateSites+Manager+plugin)
 
 ## How to launch with help of docker
 
@@ -43,3 +44,9 @@ Build image
 Next, run it with mounted plugins folder as volume. Remember to set `JUSEPPE_BASE_URI` env var
 
 `docker run --name juseppe -v /your/plugins/dir/:/juseppe/plugins/ -e JUSEPPE_BASE_URI=http://my.company.com -p 80:8080 juseppe:source`
+
+Then it will be available on `http://dockerhost:80/update-center.json`
+
+Certificate can be copied from json `signature.certificates[0]` with additional 
+`-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` with line breaks and without quotes.
+

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
                 </executions>
             </plugin>
 
-            <!--http://joelittlejohn.github.io/jsonschema2pojo/site/0.4.1/generate-mojo.html-->
+            <!--http://joelittlejohn.github.io/jsonschema2pojo/site/0.4.7/generate-mojo.html-->
             <plugin>
                 <groupId>org.jsonschema2pojo</groupId>
                 <artifactId>jsonschema2pojo-maven-plugin</artifactId>
@@ -173,4 +173,19 @@
 
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>http://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
 </project>

--- a/src/main/java/ru/lanwen/jenkins/juseppe/ServerMain.java
+++ b/src/main/java/ru/lanwen/jenkins/juseppe/ServerMain.java
@@ -23,6 +23,7 @@ import static ru.lanwen.jenkins.juseppe.files.WatchFiles.watchFor;
  * Time: 2:46
  */
 public class ServerMain {
+    public static final String JENKINS_PLUGIN_WILDCART = "*.hpi";
     public static Props props = Props.props();
 
     public static void main(String[] args) throws Exception {
@@ -41,7 +42,7 @@ public class ServerMain {
         ));
 
         context.addServlet(new ServletHolder("update-site", new DefaultServlet()), "/" + props.getName());
-        context.addServlet(new ServletHolder("plugins", new DefaultServlet()), "*.hpi");
+        context.addServlet(new ServletHolder("plugins", new DefaultServlet()), JENKINS_PLUGIN_WILDCART);
 
         Slf4jRequestLog requestLog = new Slf4jRequestLog();
         requestLog.setLogDateFormat(null);

--- a/src/main/java/ru/lanwen/jenkins/juseppe/gen/Signer.java
+++ b/src/main/java/ru/lanwen/jenkins/juseppe/gen/Signer.java
@@ -1,0 +1,163 @@
+package ru.lanwen.jenkins.juseppe.gen;
+
+import net.sf.json.JSONObject;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMReader;
+import org.jvnet.hudson.crypto.CertificateUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ru.lanwen.jenkins.juseppe.beans.Signature;
+import ru.lanwen.jenkins.juseppe.beans.UpdateSite;
+import ru.lanwen.jenkins.juseppe.util.Marshaller;
+import ru.lanwen.jenkins.juseppe.util.SignatureGenerator;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.base.Charsets.UTF_8;
+import static java.security.Security.addProvider;
+import static org.apache.commons.codec.binary.Base64.encodeBase64;
+import static org.apache.commons.lang3.Validate.isInstanceOf;
+import static ru.lanwen.jenkins.juseppe.props.Props.props;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class Signer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Signer.class);
+
+    /**
+     *  Private key to sign the update center. Must be used in conjunction with certificates
+     */
+    private File privateKey = new File(props().getKey());
+
+    /**
+     * X509 certificate for the private key given by the privateKey option. 
+     * Specify additional certificate options to pass in intermediate certificates, if any
+     */
+    private List<File> certificates = new ArrayList<File>() {{
+        add(new File(props().getCert()));
+    }};
+
+    /**
+     * Additional root certificates. Should contain your certificate if it self-signed
+     */
+    private List<File> rootCA = new ArrayList<File>() {{
+        add(new File(props().getCert()));
+    }};
+
+
+    /**
+     * Checks if the signer is properly configured to generate a signature
+     *
+     * If the configuration is partial and it's not clear whether the user intended to sign or not to sign.
+     */
+    public boolean isConfigured() {
+        LOG.info("Private key: {}, certificates: {}", privateKey, certificates);
+        return privateKey.exists() && certificates.get(0).exists();
+    }
+
+    /**
+     * Generates a canonicalized JSON format of the given object, and put the signature in it.
+     * Because it mutates the signed object itself, validating the signature needs a bit of work,
+     * but this enables a signature to be added transparently.
+     *
+     * @return The same value passed as the argument so that the method can be used like a filter.
+     */
+    public Signature sign(UpdateSite site) throws GeneralSecurityException, IOException {
+        Signature sign = new Signature();
+
+        if (!isConfigured()) {
+            LOG.warn("Can't find certificate {} or private key {}, skipping sign", certificates.get(0), privateKey);
+            return sign;
+        }
+
+        List<X509Certificate> certs = getCertificateChain();
+        X509Certificate signer = certs.get(0); // the first one is the signer, and the rest is the chain to a root CA.
+
+        FileReader reader = new FileReader(privateKey);
+
+        Object o = new PEMReader(reader).readObject();
+        isInstanceOf(KeyPair.class, o, "File %s is not rsa private key!", privateKey);
+        PrivateKey key = ((KeyPair) o).getPrivate();
+
+        SignatureGenerator signatureGenerator = new SignatureGenerator(signer, key);
+
+        String marshalledSite = Marshaller.serializer().toJson(site);
+
+        try (OutputStreamWriter output = new OutputStreamWriter(signatureGenerator.getOut(), UTF_8)) {
+            JSONObject.fromObject(marshalledSite).writeCanonical(output);
+        }
+
+        String digest = signatureGenerator.digest();
+        String signature = signatureGenerator.signature();
+
+        // first, backward compatible signature for <1.433 Jenkins that forgets to flush the stream.
+        // we generate this in the original names that those Jenkins understands.
+        sign.withDigest(digest);
+        sign.withCorrectDigest(digest);
+        
+        sign.withSignature(signature);
+        sign.withCorrectSignature(signature);
+
+        // and certificate chain
+        for (X509Certificate cert : certs) {
+            sign.getCertificates().add(new String(encodeBase64(cert.getEncoded())));
+        }
+
+        return sign;
+    }
+
+    /**
+     * Loads a certificate chain and makes sure it's valid.
+     */
+    protected List<X509Certificate> getCertificateChain() throws IOException, GeneralSecurityException {
+        CertificateFactory certsFactory = CertificateFactory.getInstance("X509");
+        List<X509Certificate> certs = new ArrayList<>();
+        for (File certFile : certificates) {
+            X509Certificate c = loadCertificate(certsFactory, certFile);
+            c.checkValidity(new Date(System.currentTimeMillis() + TimeUnit.DAYS.toMillis(30)));
+            certs.add(c);
+        }
+
+        Set<TrustAnchor> rootCAs = CertificateUtil.getDefaultRootCAs();
+        for (File f : rootCA) {
+            rootCAs.add(new TrustAnchor(loadCertificate(certsFactory, f), null));
+        }
+
+        CertificateUtil.validatePath(certs, rootCAs);
+        return certs;
+    }
+
+    private X509Certificate loadCertificate(CertificateFactory cf, File f) throws CertificateException, IOException {
+        try {
+            try (FileInputStream in = new FileInputStream(f)) {
+                X509Certificate cert = (X509Certificate) cf.generateCertificate(in);
+                cert.checkValidity();
+                return cert;
+            }
+        } catch (CertificateException | IOException e) {
+            throw (IOException) new IOException("Failed to load certificate " + f).initCause(e);
+        }
+    }
+
+    static {
+        addProvider(new BouncyCastleProvider());
+    }
+}

--- a/src/main/java/ru/lanwen/jenkins/juseppe/props/Props.java
+++ b/src/main/java/ru/lanwen/jenkins/juseppe/props/Props.java
@@ -33,6 +33,12 @@ public class Props {
     @Property("update.center.json.name")
     private String name = "update-center.json";
 
+    @Property("update.center.private.key")
+    private String key = new File("uc.key").getAbsolutePath();
+
+    @Property("update.center.certificate")
+    private String cert = new File("uc.crt").getAbsolutePath();
+
     @Property("jetty.port")
     private int port = 8080;
 
@@ -64,5 +70,13 @@ public class Props {
 
     public int getPort() {
         return port;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getCert() {
+        return cert;
     }
 }

--- a/src/main/java/ru/lanwen/jenkins/juseppe/util/Marshaller.java
+++ b/src/main/java/ru/lanwen/jenkins/juseppe/util/Marshaller.java
@@ -1,0 +1,21 @@
+package ru.lanwen.jenkins.juseppe.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ *         Date: 28.06.15
+ */
+public final class Marshaller {
+
+    private Marshaller() {
+        throw new IllegalAccessError("This class for util purposes");
+    }
+
+    public static Gson serializer() {
+        return new GsonBuilder()
+                .registerTypeAdapter(PluginListSerializer.PLUGIN_LIST_TYPE, new PluginListSerializer())
+                .setPrettyPrinting().create();
+    }
+}

--- a/src/main/java/ru/lanwen/jenkins/juseppe/util/PluginListSerializer.java
+++ b/src/main/java/ru/lanwen/jenkins/juseppe/util/PluginListSerializer.java
@@ -1,4 +1,4 @@
-package ru.lanwen.jenkins.juseppe.gen;
+package ru.lanwen.jenkins.juseppe.util;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;

--- a/src/main/java/ru/lanwen/jenkins/juseppe/util/SignatureGenerator.java
+++ b/src/main/java/ru/lanwen/jenkins/juseppe/util/SignatureGenerator.java
@@ -1,0 +1,82 @@
+package ru.lanwen.jenkins.juseppe.util;
+
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.io.output.TeeOutputStream;
+import org.jvnet.hudson.crypto.SignatureOutputStream;
+
+import java.io.IOException;
+import java.security.DigestOutputStream;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.cert.X509Certificate;
+
+import static org.apache.commons.codec.binary.Base64.encodeBase64;
+
+/**
+ * @author lanwen (Merkushev Kirill)
+ *         Date: 22.06.15
+ */
+public class SignatureGenerator {
+    public static final String SHA_1_WITH_RSA = "SHA1withRSA";
+    public static final String SHA_1 = "SHA1";
+    
+    private final MessageDigest sha1;
+    private final Signature sig;
+    private final TeeOutputStream out;
+    private final Signature verifier;
+
+    public SignatureGenerator(X509Certificate signer, PrivateKey key) throws GeneralSecurityException, IOException {
+        // this is for computing a digest
+        sha1 = MessageDigest.getInstance(SHA_1);
+        DigestOutputStream dos = new DigestOutputStream(new NullOutputStream(), sha1);
+        
+        // this is for computing a signature
+        sig = Signature.getInstance(SHA_1_WITH_RSA);
+        sig.initSign(key);
+        SignatureOutputStream sos = new SignatureOutputStream(sig);
+        
+        // this is for verifying that signature validates
+        verifier = Signature.getInstance(SHA_1_WITH_RSA);
+        verifier.initVerify(signer.getPublicKey());
+        SignatureOutputStream vos = new SignatureOutputStream(verifier);
+
+        out = new TeeOutputStream(new TeeOutputStream(dos, sos), vos);
+    }
+
+    public TeeOutputStream getOut() {
+        return out;
+    }
+
+    public MessageDigest getSha1() {
+        return sha1;
+    }
+
+    public Signature getSig() {
+        return sig;
+    }
+
+    public Signature getVerifier() {
+        return verifier;
+    }
+
+
+
+    public String digest() {
+        byte[] digest = getSha1().digest();
+        return new String(encodeBase64(digest));
+    }
+
+    public String signature() throws GeneralSecurityException {
+        byte[] signature = getSig().sign();
+        if (!getVerifier().verify(signature)) {
+            throw new GeneralSecurityException(
+                    "Signature failed to validate. " +
+                            "Either the certificate and the private key weren't matching, or a bug in the program."
+            );
+        }
+        return new String(encodeBase64(signature));
+    }
+
+}


### PR DESCRIPTION
Adds new options:

- `update.center.private.key` - path of private key (must be used in pair with cert). Defaults to *uc.key*
- `update.center.certificate` - path of certificate (must be used in pair with private key prop). Defaults to *uc.crt* 